### PR TITLE
Add development branch workflow

### DIFF
--- a/.github/actions/build-to-release-branch/action.yml
+++ b/.github/actions/build-to-release-branch/action.yml
@@ -1,0 +1,57 @@
+name: Build to release branch
+description: Merge and build a source branch into a releasable, fully-built branch.
+
+inputs:
+  source_branch:
+    description: Name of source branch.
+    required: true
+  release_branch:
+    description: Name of target release branch. Will be updated with a merge commit including built code.
+    required: true
+  built_asset_paths:
+    description: Generated assets to include in release branch commit. Overrides .gitignore.
+    required: true
+  build_script:
+    description: Command to run to build code. "npm run build" by default.
+    required: false
+
+runs:
+  using: composite
+
+  steps:
+    - name: Configure git
+      shell: bash
+      run: |
+        git config user.name "Your friendly neighborhood GH Actions Bot"
+        git config user.email "<>"
+
+    - name: Check out release branch
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.release_branch }}
+        fetch-depth: 0
+
+    - name: Merge source into release branch
+      shell: bash
+      # Simulate "-s theirs", which doesn't exist in git for sensible reasons
+      # which do not apply to our current situation.
+      # https://web.archive.org/web/20131126171744/http://www.seanius.net/blog/2011/02/git-merge-s-theirs/
+      run: |
+        git fetch origin ${{ inputs.source_branch }}
+        git fetch origin ${{ inputs.release_branch }}
+        git checkout ${{ inputs.source_branch }}
+        git checkout ${{ inputs.release_branch }}
+        git merge -s ours ${{ inputs.source_branch }}
+        git diff --binary ${{ inputs.source_branch }} | git apply -R --index
+        git commit --amend -m "Merge branch '${{ inputs.source_branch }}' into '${{ inputs.release_branch }}'"
+
+    - name: Build code
+      shell: bash
+      run: ${{ inputs.build_script }}
+
+    - name: Update release branch
+      shell: bash
+      run: |
+        git add -f ${{ inputs.built_asset_paths }}
+        git commit --amend -m "Build to '${{ inputs.release_branch }}' from ${{ inputs.source_branch }}#$( git rev-parse --short ${{ inputs.source_branch }} )"
+        git push origin ${{ inputs.release_branch }}:${{ inputs.release_branch }}

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -1,0 +1,32 @@
+name: Develop Release
+
+on:
+  push:
+    branches:
+      - develop
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    name: "Update release-develop branch"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Merge and build
+        uses: ./.github/actions/build-to-release-branch
+        with:
+          source_branch: develop
+          release_branch: release-develop
+          built_asset_paths: build
+          build_script: |
+            npm ci
+            npm run build

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -25,7 +25,7 @@ jobs:
         uses: ./.github/actions/build-to-release-branch
         with:
           source_branch: develop
-          release_branch: release-develop
+          release_branch: develop-built
           built_asset_paths: build
           build_script: |
             npm ci

--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ This plugin requires a small amount of JS and CSS in order to work properly, and
 4. GitHub Actions should auto-build the frontend assets and reset that tag to push to the bundled code
 
 Check the build output in the Actions tab to see whether it works or not.
+
+### Development Builds
+
+To test the plugin on a deployed instance via composer, register the repository as a VCS source, and set your `humanmade/hm-post-history` dependency to track the `dev-develop-built` branch source.
+
+Merge PRs which require development testing into the `develop` branch, and they will be automatically built and pushed to that `develop-built` branch using a GitHub Action.
+
+If code which is not intended for release ends up on `develop`, force-reset both `develop` and `develop-built` to match the latest `main`.


### PR DESCRIPTION
The current build workflow only supports version number-tagged production releases, which makes it difficult to test things on a development instance. To enable better usage on our test instance, this PR implements a GH action to build to a `develop-built` branch upon merge to this repository's `develop` branch.