### PR TITLE
Remove unnecessary margins on Load More button

### DIFF
--- a/assets/src/styles/index.scss
+++ b/assets/src/styles/index.scss
@@ -82,8 +82,6 @@
 		padding: calc( 0.4166666667rem + 1px ) 15px;
 		color: var( --post-history-accent );
 		background: #fff;
-		margin-bottom: 0.8333333335rem;
-		margin-right: 7.5px;
 		display: inline-block;
 		text-align: center;
 		cursor: pointer;


### PR DESCRIPTION
<img width="228" alt="image" src="https://user-images.githubusercontent.com/442115/209453081-6386c764-9030-4611-a598-956d73408f94.png">

The margins from v1 of this widget are not needed in the newer design and cause the load more button to appear out of alignment

Relates to humanmade/hm-playbook-theme#530